### PR TITLE
chore: update the import.meta.glob syntax to be more specific

### DIFF
--- a/src/pages/ClanPage.jsx
+++ b/src/pages/ClanPage.jsx
@@ -27,13 +27,13 @@ function ClanPage() {
         };
 
         const fetchClanCharacters = async () => {
-            const allCharacterModules = import.meta.glob('../content/**/*.md', { as: 'raw' });
+          const allCharacterModules = import.meta.glob('../content/**/*.md', { query: '?raw', import: 'default' });
 
             const characterPromises = Object.entries(allCharacterModules)
                 // filter for paths that are in the current clan's directory
-                .filter(([path, _]) => path.startsWith(`../content/${clan}/`))
+                .filter(([path, ]) => path.startsWith(`../content/${clan}/`))
                 // IMPORTANT: also filter out the _index.md file itself!
-                .filter(([path, _]) => !path.endsWith('_index.md'))
+                .filter(([path, ]) => !path.endsWith('_index.md'))
                 .map(async ([path, importer]) => {
                     const fileContent = await importer();
                     const { data } = matter(fileContent);


### PR DESCRIPTION
## Description

This PR updates a single line in `ClanPage.jsx` that brings the project up to date for the `import.meta.glob` syntax. Everything still works exactly the same.

## What's Changed?

- **A single line of code**:
  - Uses the new and standard Vite method to extract the raw text content from the markdown files. Now, when you use `npm run dev`, you should no longer get the warning below.

```
The glob option "as" has been deprecated in favour of "query". Please update as: 'raw'toquery: '?raw', import: 'default'.
```