### PR TITLE
style: make pagination buttons smaller and push indicators higher

### DIFF
--- a/src/components/ImageCarousel.jsx
+++ b/src/components/ImageCarousel.jsx
@@ -63,14 +63,14 @@ function ImageCarousel({ images, type, clan, characterName }) {
             ))}
             
             {/* pagination buttons */}
-            <button className="custom-prev absolute left-4 top-1/2 -translate-y-1/2 z-10 w-10 h-10 bg-black/50 rounded-full cursor-pointer">
+            <button className="custom-prev absolute left-4 top-1/2 -translate-y-1/2 z-10 w-8 h-8 bg-black/50 rounded-full cursor-pointer">
                 <img 
                     src={`${import.meta.env.BASE_URL}/assets/icons/arrow-left-stroke.png`} 
                     alt="Previous" 
                     className="w-full h-full"
                 />
             </button>
-            <button className="custom-next absolute right-4 top-1/2 -translate-y-1/2 z-10 w-10 h-10 bg-black/50 rounded-full cursor-pointer rotate-180">
+            <button className="custom-next absolute right-4 top-1/2 -translate-y-1/2 z-10 w-8 h-8 bg-black/50 rounded-full cursor-pointer rotate-180">
                 <img 
                     src={`${import.meta.env.BASE_URL}/assets/icons/arrow-left-stroke.png`} 
                     alt="Next" 

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@
     }
     
     /* image carousel pagination bullets */
-    .custom-carousel .swiper-pagination { @apply flex justify-center items-center w-full! }
+    .custom-carousel .swiper-pagination { @apply flex justify-center items-center w-full! mb-2 }
     .custom-carousel .swiper-pagination::before { content: ''; @apply absolute -z-1 px-4 py-2 bg-black/50 rounded-full }
     .custom-carousel .swiper-pagination-bullet-active { @apply bg-white! }
     .custom-carousel .swiper-pagination-bullet { @apply bg-gray-200! }


### PR DESCRIPTION
## Description

This PR just makes small visual changes to `ImageCarousel`.

## What's Changed?

- **Smaller pagination buttons**:
  - The `ImageCarousel`'s pagination buttons were made a bit smaller because they were a little too big previously.
- **Higher pagination indicators**:
  - Added a bit of a bottom margin to the pagination indicators to push it a little higher, to be more visible.

## Screenshots

<img width="289" height="336" alt="image" src="https://github.com/user-attachments/assets/8f110d5a-f57f-4a40-868c-cda478afdbf2" />
<img width="289" height="336" alt="image" src="https://github.com/user-attachments/assets/383792a0-c93c-4fd9-96e7-3db155b98626" />