### PR TITLE
fix: filter out 'no clan' and 'bloodlines' from BreadCrumbs

### DIFF
--- a/src/components/BreadCrumbs.jsx
+++ b/src/components/BreadCrumbs.jsx
@@ -18,8 +18,8 @@ function BreadCrumbs() {
     const path = location.pathname; // "/clan/brujah"
     const parts = path.split("/").filter(Boolean);
 
-    // filter out 'clan' from the parts array
-    const filteredParts = parts.filter(part => part !== 'clan');
+    // filter out the 'middleman' (clan/non clan/bloodlines/etc) from the parts array
+    const filteredParts = parts.filter(part => !['clan', 'bloodline', 'non-clan'].includes(part));
 
     // split into parts and remove empty "" from '/'
     const crumbs = filteredParts.map((part) => { // removed unused 'idx'


### PR DESCRIPTION
## Description

This PR fixes the issue of the 'middleman' BreadCrumb in between 'Home' and the 'Clan'.

## What's Changed?

- **No more middle-crumbs**:
  - Expanded the filter in `BreadCrumbs` to cover both `non clan` and `bloodlines`.  This was fixed back when there were only the main clans, but now it should also be fixed for the poor Caitiff and Thin-Bloods.

## Screenshots

<img width="363" height="66" alt="image" src="https://github.com/user-attachments/assets/975881e3-c083-4ea8-a146-85afee701a6a" />
<img width="304" height="66" alt="image" src="https://github.com/user-attachments/assets/6fcfa91a-ae5c-4078-bd15-998b1d69258a" />
