### PR TITLE
style: separate <link> global styling for Page Links and Breadcrumbs

### DIFF
--- a/src/components/BreadCrumbs.jsx
+++ b/src/components/BreadCrumbs.jsx
@@ -90,7 +90,7 @@ function BreadCrumbs() {
 
                         {/* last crumb is active and unclickable */}
                         {i === crumbs.length - 1 ? (
-                            <span className="px-3 py-1 text-red-600 bg-red-100 rounded-md">
+                            <span className="px-2 py-1 text-red-600 bg-red-100 rounded-md sm:px-3">
                                 {crumb.name}
                             </span>
                         ) : (

--- a/src/index.css
+++ b/src/index.css
@@ -33,7 +33,7 @@
     /* paragraph */
     p { @apply text-sm sm:text-base }
     /* link cursor */
-    a { @apply text-sm cursor-pointer
+    .pageLink { @apply text-sm cursor-pointer
     /* placeholder */
     px-5 py-2 text-gray-600 bg-gray-100 rounded-md transition hover:text-black hover:bg-gray-200 sm:text-base
     }

--- a/src/pages/ClanPage.jsx
+++ b/src/pages/ClanPage.jsx
@@ -73,7 +73,7 @@ function ClanPage() {
                         {characters.length > 0 ? (
                             <nav className="flex flex-col w-fit pl-2 border-l-4 border-gray-300 mt-4">
                                 {characters.map((char) => (
-                                  <Link key={char.slug} to={`/${type}/${clan}/${char.slug}`}>
+                                  <Link key={char.slug} to={`/${type}/${clan}/${char.slug}`} className="pageLink">
                                         {char.name}
                                     </Link>
                                 ))}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -41,7 +41,7 @@ function HomePage(){
                 <nav className="flex flex-col w-fit pl-2 border-l-4 border-gray-300 mt-4">
                     {clanLinks.map((link) => (
                             // change <a> to custom link component when made!
-                            <Link key={link.href} to={link.href}>
+                            <Link key={link.href} to={link.href} className="pageLink">
                                 {link.text}
                             </Link>
                     ))}
@@ -53,7 +53,7 @@ function HomePage(){
                 <nav className="flex flex-col w-fit pl-2 border-l-4 border-gray-300 mt-4">
                     {bloodlineLinks.map((link) => (
                             // change <a> to custom link component when made!
-                            <Link key={link.href} to={link.href} className="line-through">
+                            <Link key={link.href} to={link.href} className="pageLink line-through">
                                 {link.text}
                             </Link>
                     ))}
@@ -65,7 +65,7 @@ function HomePage(){
                 <nav className="flex flex-col w-fit pl-2 border-l-4 border-gray-300 mt-4">
                     {nonclanLinks.map((link) => (
                             // change <a> to custom link component when made!
-                            <Link key={link.href} to={link.href}>
+                            <Link key={link.href} to={link.href} className="pageLink">
                                 {link.text}
                             </Link>
                     ))}


### PR DESCRIPTION
Links are no longer styled globally, and inactive breadcrumbs (the grey ones) are no longer fatter than active (red) crumbs.

## What's changed?
- **New `.pageLink` style class**:
  - Previously, the breadcrumb links weren't uniform, specifically the active and inactive ones, as the grey crumbs would be larger than the red crumbs. This was due to a *placeholder* global styling for `<a>` that was applied to both Page Links and `BreadCrumbs` crumbs (which are also links).
  - The global `<a>` styling is now applied to `.pageLink`, which is applied only to `Page` components.

## Look 👀
<img width="679" height="202" alt="image" src="https://github.com/user-attachments/assets/a9dbd277-1da8-4aed-bcce-a0a89d5ad7f1" />
<img width="679" height="202" alt="image" src="https://github.com/user-attachments/assets/fa8f7807-ce6c-4d9f-872b-28c9d629554c" />

## Follow-up
- Fix `ImageCarousel` group-hover to only apply on larger screens, as pagination and captions simply don't appear on mobile.