### PR TITLE
fix: prevent reloads causing 404 errors on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Creates a Vercel config file to rewrite requests to index.html.

## What's changed?
- **No more 404s**:
  - The same issue that happened on Pages happened, where reloading on a page that's *not* `HomePage` would return a `404: Not Found` error. Vercel seems to have given the project a vanilla, non-SPA configuration.
  - The new `vercel.json` file just tells Vercel to refer to `index.html` (who then invokes the React router), so the 404 routing issue is fixed.