### PR TITLE
fix: remove white background from ImageCarousel; invert colors for clan symbols

### DIFF
--- a/src/components/ImageCarousel.jsx
+++ b/src/components/ImageCarousel.jsx
@@ -30,16 +30,22 @@ function ImageCarousel({ images, type, clan, characterName }) {
       }
       return imageFile; // fallback
     };
-    
-    // for single vs. multiple images
+  
+    // CHECK: is this a clan symbol?
+    // YES: add invert filter for dark mode
+    const imageClasses = `w-full h-full object-contain rounded-md transition-all ${
+        type === 'clan' ? 'dark:brightness-0 dark:invert opacity-80' : ''
+    }`;
+  
+    // for single images
     if (images.length === 1) {
         const image = images[0];
         return (
-            <div className="group relative w-full h-fit mb-4 dark:bg-bg-primary rounded-md">
+            <div className="group relative w-full h-fit mb-4 rounded-md">
                 <img
                     src={getImagePath(image.file)} // <-- use image.file
                     alt={characterName || 'Image'}
-                    className="w-full h-full object-contain"
+                    className={imageClasses}
                 />
                 {/* conditionally render the caption */}
                 {image.artist && (
@@ -66,14 +72,14 @@ function ImageCarousel({ images, type, clan, characterName }) {
             }}
             pagination={{ clickable: true }}
             loop={true}
-            className="custom-carousel group relative w-full h-fit mb-4 dark:bg-bg-primary rounded-md"
+            className="custom-carousel group relative w-full h-fit mb-4 rounded-md"
         >
             {images.map((image, index) => ( // <-- `image` is now an object
                 <SwiperSlide key={index}>
                     <img
                       src={getImagePath(image.file)} // <-- Use image.file
                       alt={`${characterName || 'Image'} - ${index + 1}`}
-                      className="w-full h-full object-contain rounded-md"
+                      className={imageClasses}
                     />
                     {/* conditionally render the caption inside the slide */}
                     {image.artist && (


### PR DESCRIPTION
In #36, the image carousel had a white background because in dark mode, the clan symbols were black, and it was difficult to make out from the dark background. However, it also flash-banged the user with a bright element in an otherwise dark site. Now, there is no more flash bang, and the colors of the images are inverted--so it's even a nice off-white/gray-ish color!

## What's changed?
- **No blinding lights**
  - The white background of `ImageCarousel` containers is now gone.
- **Visible clan symbols in dark mode**
  - In dark mode, the colors of the clan symbols (png of a simple pure-black symbol on a transparent background) are inverted, meaning that it appears as a light color.

## Look 👀

Before:
<img width="806" height="523" alt="image" src="https://github.com/user-attachments/assets/0bd9e1a9-d90b-4649-9770-fba3a8a1a649" />

After:
<img width="802" height="520" alt="image" src="https://github.com/user-attachments/assets/6458e3f5-3bb7-45c1-9876-3216ed2b5ecc" />

---

Closes #38