### PR TITLE
fix: prevent Panel width-sizing issues

### DIFF
--- a/src/pages/[type]/[clan]/[character]/index.astro
+++ b/src/pages/[type]/[clan]/[character]/index.astro
@@ -57,7 +57,7 @@ const { Content } = await render(char);
             </div>
 
             <!-- RIGHT: Sidebar (DetailPanel + Sheet) -->
-            <aside class="flex flex-col gap-6 md:w-5/12 order-first md:order-last">
+            <aside class="flex flex-col gap-6 md:min-w-[45%] order-first md:order-last">
                 <DetailPanel 
                     client:load 
                     type="character" 

--- a/src/pages/[type]/[clan]/index.astro
+++ b/src/pages/[type]/[clan]/index.astro
@@ -88,13 +88,13 @@ const { Content } = await render(clanInfo);
 
             {/* detail sidebar pane */}
             {/* Hydrate this with client:load because it contains the ImageCarousel which needs interactivity */}
-            <div class="order-first md:order-last">
+            <aside class="md:min-w-[45%] order-first md:order-last">
                 <DetailPanel 
                     client:load 
                     type="clan" 
                     data={clanInfo.data}  
                 />
-            </div>
+            </aside>
         </section>
     </div>
 </Layout>


### PR DESCRIPTION
Fixed an issue where `DetailPanel` in both Clan and Character Pages were not properly sized.

## What's changed?

- Specified a minimum-width of `45%` for the `aside` elements (containers for `DetailPanel` and `CharacterSheetPanel`.
  - The Clan Lasombra page's Panel should no longer be incredibly fat.
  - The `DetailPanel` in Character Page should no longer initially load small, then suddenly and jarringly snap to proper size.

---

> Closes #59 - Added specific `min-w-[45%]` to Panel containers.