### PR TITLE
fix: modify scrollbar to show in both light/dark modes

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,14 +52,34 @@
     /* text-gray-400 */
 }
 
+/*
+# 
+#   RE-ORGANIZE THE @LAYERS!!!!!!
+#
+*/
+
+
 @layer base {
-    html {
-        @apply bg-bg-primary dark:bg-bg-primary-dark text-text-primary dark:text-text-primary-dark
+    
+    ::-webkit-scrollbar {
+        width: 3px;
+        height: 5px;
     }
+
+    ::-webkit-scrollbar-thumb {
+        background-color: rgb(184, 184, 184);
+        opacity: 50%;
+        border-radius: 9999px;
+    }
+
 }
 
 /* classes */
 @layer utilities {
+
+    html {
+        @apply bg-bg-primary dark:bg-bg-primary-dark text-text-primary dark:text-text-primary-dark
+    }
 
     /* big boi base */
     body {


### PR DESCRIPTION
Scrollbar should no longer be dark in dark mode for Chromium browsers (as well as Firefox)

## What's changed?

- **New scrollbar look**:
  - Instead of just setting the theme color for `root`, the scrollbar itself is modified.
    - It's slimmer/thinner now, with no trackpad.
    - The scrollbar thumb is also a specific light-grey color and is rounded.

## Look 👀

<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/a6293d52-ced2-4b7b-9fca-41432419f229" />
<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/5060ee3f-abdf-461f-9573-830e81bbc6a1" />

## Follow-up

- Reorganize `global.css` `@layers` into proper `base`, `components`, and `utilities`.

---

> Closes #61 - Specifies color for scrollbar