### PR TITLE
style: add viewtransitions persistence to Panel containers [VAULT-2]

### DIFF
--- a/src/pages/[type]/[clan]/[character]/index.astro
+++ b/src/pages/[type]/[clan]/[character]/index.astro
@@ -57,7 +57,7 @@ const { Content } = await render(char);
             </div>
 
             <!-- RIGHT: Sidebar (DetailPanel + Sheet) -->
-            <aside class="flex flex-col gap-6 md:min-w-[45%] order-first md:order-last">
+            <aside class="flex flex-col gap-6 md:min-w-[45%] order-first md:order-last" transition:name="panels">
                 <DetailPanel 
                     client:load 
                     type="character" 

--- a/src/pages/[type]/[clan]/index.astro
+++ b/src/pages/[type]/[clan]/index.astro
@@ -88,7 +88,7 @@ const { Content } = await render(clanInfo);
 
             {/* detail sidebar pane */}
             {/* Hydrate this with client:load because it contains the ImageCarousel which needs interactivity */}
-            <aside class="md:min-w-[45%] order-first md:order-last">
+            <aside class="md:min-w-[45%] order-first md:order-last" transition:name="panels">
                 <DetailPanel 
                     client:load 
                     type="clan" 


### PR DESCRIPTION
Adds persistent ViewTransitions to the Panel (`DetailPanel` and `CharacterSheetPanel`) containers.

However, this will probably be removed soon 😅

## What's changed?

- **Temp persistence**:
  - `transition:name` was added to the `<aside>` element (Panel container)

---

> Closes #62 - Added persistence to `<aside>` panel container.